### PR TITLE
added jump examples used in benchmarking

### DIFF
--- a/src/DiffEqProblemLibrary.jl
+++ b/src/DiffEqProblemLibrary.jl
@@ -51,6 +51,6 @@ export prob_jump_dnarepressor, prob_jump_constproduct, prob_jump_nonlinrxs,
 # examples mixing mass action and constant rate jumps
        prob_jump_osc_mixed_jumptypes,
 # examples used in published benchmarks / comparisions
-       prob_jump_multistate
+       prob_jump_multistate, prob_jump_twentygenes, prob_jump_dnadimer_repressor
 
 end # module


### PR DESCRIPTION
Here I've added two networks that were used in (published) SSA benchmarks. This should ultimately help us see how our implementations are performing relative to the published benchmarks (for example, due to priority queue issues the NRM is performing much poorer relative to the direct method that is seen in the published benchmarks).

The specific networks added here are

1. Negative feedback auto-regulatory gene expression model, where feedback is by dimers of the expressed protein.
2. A 20 gene network with switching behavior that was used as an example where the sorting direct method can greatly outperform the direct method.