### PR TITLE
Bump DiffEqBase compat to include v7 across problem-library sublibs

### DIFF
--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "BVProblemLibrary"
 uuid = "ded0fc24-dfea-4565-b1d9-79c027d14d84"
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -9,7 +9,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Aqua = "0.8"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 Markdown = "1.10"
 SpecialFunctions = "2.3"
 julia = "1.10"

--- a/lib/DAEProblemLibrary/Project.toml
+++ b/lib/DAEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "DAEProblemLibrary"
 uuid = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -8,7 +8,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
 Aqua = "0.8"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 Markdown = "1.10"
 julia = "1.10"
 

--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -1,13 +1,13 @@
 name = "DDEProblemLibrary"
 uuid = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 
 [compat]
 Aqua = "0.8"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 julia = "1.10"
 
 [extras]

--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "ODEProblemLibrary"
 uuid = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -10,7 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Aqua = "0.8"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 LinearAlgebra = "1.10"
 Markdown = "1.10"
 Random = "1.10"

--- a/lib/SDEProblemLibrary/Project.toml
+++ b/lib/SDEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "SDEProblemLibrary"
 uuid = "c72e72a9-a271-4b2b-8966-303ed956772e"
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -10,10 +10,10 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 Aqua = "0.8"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 Markdown = "1.10"
 RuntimeGeneratedFunctions = "0.5"
-SciMLBase = "2.0.1"
+SciMLBase = "2.0.1, 3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

Widen `DiffEqBase = "6"` → `DiffEqBase = "6, 7"` on every sublibrary that depends on DiffEqBase, and widen SDEProblemLibrary's `SciMLBase = "2.0.1"` → `"2.0.1, 3"` as well. This lets the sublibs be installed alongside the in-development DiffEqBase 7.0.0 / SciMLBase 3 (shipped with OrdinaryDiffEq.jl v7, currently at `lib/DiffEqBase` in the OrdinaryDiffEq monorepo).

Per-sublib version bumps (non-breaking compat widening):

| Sublib                     | Before → After |
|----------------------------|----------------|
| ODEProblemLibrary          | 1.4.0 → 1.5.0  |
| DDEProblemLibrary          | 0.1.4 → 0.1.5  |
| SDEProblemLibrary          | 1.1.1 → 1.2.0  |
| BVProblemLibrary           | 0.1.8 → 0.1.9  |
| DAEProblemLibrary          | 0.1.2 → 0.1.3  |

**Out of scope:**
- **JumpProblemLibrary**: also pins `Catalyst = "15"`, which is two majors behind the current Catalyst 16.1.1. Widening it properly needs a Catalyst bump too, which belongs in its own PR.
- **NonlinearProblemLibrary**: no DiffEqBase dep, untouched.

## Motivation

On SciML/OrdinaryDiffEq.jl#3488 (the v7 release branch), the `test (Interface{I..V}, …)` matrix and several other test groups fail at resolve time with:

```
ERROR: LoadError: Unsatisfiable requirements detected for package ODEProblemLibrary [fdc4e326]:
 ├─possible versions are: 0.1.0 - 1.4.0 or uninstalled
 └─restricted by compatibility requirements with DiffEqBase [2b5f629d] to versions: uninstalled — no versions left
   └─DiffEqBase [2b5f629d] is fixed to version 7.0.0
```

The `lib/DiffEqBase` v7 from the OrdinaryDiffEq monorepo is dev'd into every test env, while ODEProblemLibrary (and the other problem libs pulled in transitively through DiffEqDevTools test deps) come from the General registry with their `DiffEqBase = "6"` cap. This PR widens that cap.

## Why this is source-level safe

These are problem-definition libraries. Each one does nothing but construct `ODEProblem` / `DDEProblem` / `SDEProblem` / `BVProblem` / `DAEProblem` instances and expose them as module-level globals for downstream solver tests. Their DiffEqBase surface is tiny and entirely stable across the v7 rename:

- grepped every sublib's `src/` for every symbol removed in the v7 NEWS (`u_modified!`, `has_destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `.destats`, `DEAlgorithm`/`DEProblem`/`DESolution` as standalone names, `tuples()`/`intervals()`) → zero matches across all five bumped sublibs.
- None of the sublibs `import` or `use` any symbol that was removed or renamed; the problem-type constructors (`ODEProblem`, etc.) are re-exported from both DiffEqBase 6 and 7 unchanged.

## Test plan

- [x] Source grep for every removed v7 / v3 symbol — clean.
- [ ] CI on this PR (against the currently-registered DiffEqBase 6.x — no source changes; expected green).
- [ ] OrdinaryDiffEq.jl#3488 resolver: the `Unsatisfiable requirements detected for package ODEProblemLibrary` (and sibling) lines should disappear once these are registered.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>