### PR TITLE
NonlinearProblemLibrary: support SciMLBase v3

### DIFF
--- a/lib/NonlinearProblemLibrary/Project.toml
+++ b/lib/NonlinearProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearProblemLibrary"
 uuid = "b7050fa9-e91f-4b37-bcee-a89a063da141"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,7 +10,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 AllocCheck = "0.2"
 Aqua = "0.8"
 LinearAlgebra = "1.6"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
- Bumps `NonlinearProblemLibrary` SciMLBase compat from `"2"` to `"2, 3"` so the subpackage can resolve under the OrdinaryDiffEq v7 / DiffEqBase v7 stack (which requires SciMLBase v3).
- Bumps `NonlinearProblemLibrary` version from `0.1.4` to `0.1.5`.
- No code changes needed: the library only constructs `NonlinearProblem` instances and stores reference solutions; none of the SciMLBase v2→v3 breaking APIs (`destats`, symbol `retcode` comparison, `DEAlgorithm`/`DEProblem`/`DESolution`, `IntegralProblem` `nout`/`batch`, etc.) are used.

## Why
SciMLBenchmarks.jl's `NonlinearProblem` benchmark folder cannot resolve under the OrdinaryDiffEq v7 stack because `NonlinearProblemLibrary v0.1.4` caps SciMLBase at `1.0.0 - 2.155.1`. The v7 stack (DiffEqBase v7, OrdinaryDiffEq v7, RecursiveArrayTools v4) requires SciMLBase v3. Bumping NonlinearProblemLibrary's SciMLBase compat is the only thing in this repo blocking the benchmark from resolving. See https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md for the SciMLBase v3 migration notes.

## Scope
Only `lib/NonlinearProblemLibrary/Project.toml` is touched. Sibling subpackages were checked:
- `SDEProblemLibrary` already declares `SciMLBase = "2.0.1, 3"` (no change needed).
- `BVProblemLibrary`, `DAEProblemLibrary`, `DDEProblemLibrary`, `JumpProblemLibrary`, `ODEProblemLibrary` do not pin SciMLBase directly in their `[compat]`. They could potentially benefit from explicit v3 compat declarations (and audits of their indirect SciMLBase usage), but that is out of scope for unblocking the SciMLBenchmarks NonlinearProblem benchmark and should be handled in follow-up PRs.

## Test plan
- [x] NonlinearProblemLibrary's own `Pkg.test()` passes locally on Julia 1.11 with SciMLBase 3.7.1 resolved (Aqua + AllocCheck suites all pass).
- [ ] CI green on this PR.
- [ ] Downstream SciMLBenchmarks NonlinearProblem benchmark resolves the v7 stack after a tagged release.

### Local test output (Julia 1.11, SciMLBase 3.7.1)
```
Test Summary:           | Pass  Total  Time
Unbound type parameters |    1      1  0.1s
Test Summary:     | Pass  Total  Time
Undefined exports |    1      1  0.0s
Test Summary:                              | Pass  Total  Time
Compare Project.toml and test/Project.toml |    1      1  0.0s
Test Summary:      | Pass  Total  Time
Stale dependencies |    1      1  2.7s
Test Summary: | Pass  Total  Time
Compat bounds |    4      4  0.3s
Test Summary: | Pass  Total  Time
Piracy        |    1      1  0.1s
Test Summary:    | Pass  Total   Time
Persistent tasks |    1      1  11.9s
Test Summary:    | Pass  Total  Time
Allocation Tests |    3      3  1.3s
     Testing NonlinearProblemLibrary tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)