### PR TITLE
Migrate downgrade CI to the centralized inherit form

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,21 +11,13 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  downgrade:
+    name: "Downgrade"
     strategy:
       matrix:
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Migrates the Downgrade workflow from inline steps to the shared `SciML/.github/.github/workflows/downgrade.yml@v1` reusable workflow (`secrets: inherit`), matching the repos already updated to this form. The reusable workflow defaults `allow-reresolve: false` (genuine test-at-floor). julia-version/group matrix + skip preserved. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)