### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,23 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,Markdown"
+      allow-reresolve: true


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What

Adds `.github/workflows/DowngradeSublibraries.yml`, a thin caller that invokes the centralized SciML reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1`. That reusable workflow auto-discovers every `lib/*` package containing a `Project.toml` and, for each, runs `julia-downgrade-compat` + `julia-buildpkg` + `julia-runtest` against `project: lib/<sub>`. This catches breakage against the oldest declared-compatible dependency versions, per-sublibrary.

This is complementary to the existing root-level `Downgrade.yml` (which downgrade-tests the top-level package); this new workflow covers the `lib/*` sublibraries.

## Sublibraries covered (7)

All discovered automatically (no explicit `projects` list), each has a `test/runtests.jl`:
- BVProblemLibrary
- DAEProblemLibrary
- DDEProblemLibrary
- JumpProblemLibrary
- NonlinearProblemLibrary
- ODEProblemLibrary
- SDEProblemLibrary

## Configuration

- `julia-version: lts`
- `allow-reresolve: true`
- `skip` (deps NOT downgraded): `Pkg, TOML, Statistics, LinearAlgebra, SparseArrays, InteractiveUtils, Random, Test, Markdown`

Only standard libraries are skipped. None of the sublibraries declare in-repo path/dev dependencies (all their deps — `DiffEqBase`, `SciMLBase`, `Catalyst`, `RuntimeGeneratedFunctions`, `SpecialFunctions`, etc. — are external registry packages), so no in-repo core/base package needed to be added to `skip`. `Markdown`, `LinearAlgebra`, and `Random` are stdlibs used by some sublibraries and are skipped accordingly.

## Heads up

This adds new required-looking CI checks (one downgrade job per sublibrary, ~7 jobs). Expect new entries in the checks list on every PR/push to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)