### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,17 +21,7 @@ jobs:
         version:
           - "1"
           - "lts"
-        project:
-          - '.'
-          - 'lib/DAEProblemLibrary'
-          - 'lib/DDEProblemLibrary'
-          - 'lib/JumpProblemLibrary'
-          - 'lib/ODEProblemLibrary'
-          - 'lib/SDEProblemLibrary'
-          - 'lib/BVProblemLibrary'
-          - 'lib/NonlinearProblemLibrary'
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"
-      project: "${{ matrix.project }}"
     secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -1,0 +1,18 @@
+name: Sublibrary CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  sublibrary-ci:
+    uses: "SciML/.github/.github/workflows/sublibrary-tests.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Centralizes this monorepo's GitHub Actions onto the shared `SciML/.github` reusable workflows (`@v1`), preserving the repo's existing config (version matrix, default branch `master`, triggers, paths-ignore, concurrency) and dropping no CI coverage.

## Converted / consolidated workflows

| File | Before | After |
|------|--------|-------|
| `CI.yml` (Tests) | `tests.yml@v1` with a manual `project:` matrix listing `.` + all 7 `lib/*` sublibraries, over version `["1","lts"]` | clean main-package caller of `tests.yml@v1` over version `["1","lts"]` (project `.` only) |
| `SublibraryCI.yml` | (new) | caller of `sublibrary-tests.yml@v1` — auto-discovers `lib/*`, replacing the per-sublibrary `project:` entries that used to live in `CI.yml` |
| `FormatCheck.yml` | bespoke `fredrikekre/runic-action@v1` | `runic.yml@v1` |
| `SpellCheck.yml` | bespoke `crate-ci/typos` | `spellcheck.yml@v1` |

## Sublibrary handling (monorepo)

This repo is a real monorepo: each of the 7 `lib/<name>/` dirs has its own `Project.toml` and `test/runtests.jl`. The old `CI.yml` tested them by enumerating them in a `project:` matrix on `tests.yml`. That per-sublibrary CI is now consolidated into a single `SublibraryCI.yml` calling `sublibrary-tests.yml@v1`, which auto-discovers `lib/*` and runs only the sublibraries affected by a change. `CI.yml` is now reserved for the top-level `DiffEqProblemLibrary` package itself.

Note: `sublibrary-tests.yml@v1` reads optional per-sublibrary config from `lib/<name>/test/test_groups.toml`. None exist here, so the reusable's defaults apply. The draft PR's own CI run will exercise this.

## Intentionally left bespoke / untouched

- **`Downgrade.yml`** — already a thin caller of `downgrade.yml@v1` (julia `1.10`, skip `Pkg,TOML`). Already reusable, so untouched. No `DowngradeSublibraries.yml` existed, so none was created (no existing sublibrary-downgrade coverage to preserve).
- **`TagBot.yml`** — non-CI release automation (`JuliaRegistries/TagBot`); no reusable equivalent. Left local.

## NOTE: required-status-check names change

Routing through the reusables changes the **job names** that appear as status checks, so branch protection on `master` must be updated:
- `Tests` job names now come from `tests.yml@v1` / `sublibrary-tests.yml@v1` reusable jobs.
- Format and spell-check job names now come from `runic.yml@v1` / `spellcheck.yml@v1`.

Update the required-status-check list accordingly after merge, or required checks will appear "expected" forever.

---

Please ignore until reviewed by @ChrisRackauckas.