### PR TITLE
ci: uniformize onto centralized CI (project-model SublibraryCI + cleanup)

### DIFF
--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -4,15 +4,19 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  sublibrary-ci:
-    uses: "SciML/.github/.github/workflows/sublibrary-tests.yml@v1"
+  sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
Uniformizes this repo onto the centralized CI setup released in SciML/.github `@v1`:

- Migrate SublibraryCI to the project-model `sublibrary-project-tests.yml@v1`

**Deliberately excluded:** TagBot centralization (the reusable `tagbot.yml` only wraps `JuliaRegistries/TagBot@v1`, which already floats — near-zero value, and rewriting the sublib matrix risks silently dropping a package from registration); `dependabot-automerge` / `runic-suggestions` (opt-in behavior changes).

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)