### PR TITLE
ci: remove CompatHelper / clean dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"


### PR DESCRIPTION
Mechanical CI uniformization.

Remove the `crate-ci/typos` ignore entry from `.github/dependabot.yml`. Packages should not pin `crate-ci/typos`; minor/patch updates should flow through Dependabot automatically. The `julia` and `github-actions` ecosystem blocks are preserved.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)