### PR TITLE
style: apply Runic v1.7.0 formatting

### DIFF
--- a/lib/ODEProblemLibrary/src/brusselator_prob.jl
+++ b/lib/ODEProblemLibrary/src/brusselator_prob.jl
@@ -117,7 +117,7 @@ function brusselator_1d_loop(du, u, p, t)
     A, B, alpha, dx = p
     alpha = alpha / dx^2
     N = N_brusselator_1d
-    @inbounds for i in 1:N
+    return @inbounds for i in 1:N
         ip1 = limit(i + 1, N)
         im1 = limit(i - 1, N)
         du[i, 1] = alpha * (u[im1, 1] + u[ip1, 1] - 2u[i, 1]) +


### PR DESCRIPTION
## Summary

This is a standalone, pure-formatting PR that runs **Runic v1.7.0** (the exact version used by the centralized SciML `runic.yml@v1` CI workflow) in-place over the repository to make the **Runic Format Check** pass.

- No logic changes, no CI/Project.toml changes, no non-`.jl` changes.
- The single diff is in `lib/ODEProblemLibrary/src/brusselator_prob.jl`: Runic adds an explicit `return` to a trailing `@inbounds for` loop (Runic's explicit-return rule).
- After reformatting, `Runic.main(["--check", "--diff", "."])` exits 0 (no remaining diffs) across all 29 tracked `.jl` files.

This is intentionally a separate, self-contained formatting PR so it can be reviewed and merged independently of any other work.

> **Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)