### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,26 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        # Only the root umbrella package's own test groups are listed here.
-        # The lib/* sublibraries are covered by SublibraryCI.yml (project model);
-        # they are intentionally not re-tested through the root matrix.
-        group:
-          - Core
-          - QA
-        version:
-          - "lts"
-          - "1"
-          - "pre"
-        exclude:
-          # QA (explicit-imports check) does not need the pre-release Julia.
-          - group: QA
-            version: "pre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,8 @@
+# Root umbrella package's own test groups (group x version matrix).
+# The lib/* sublibraries are covered by SublibraryCI.yml (project model) and are
+# intentionally not re-tested through this root matrix.
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the **root** test workflow (`.github/workflows/CI.yml`, status check `name: "Tests"`) from a hand-maintained `group × version` matrix that directly called `tests.yml@v1` into a thin caller of the new `grouped-tests.yml@v1`. The matrix now lives once in a new root `test/test_groups.toml`.

`SublibraryCI.yml` (the `sublibrary-project-tests.yml@v1` project-model workflow) is intentionally **left untouched** — this PR only touches the root umbrella package's own test groups.

### `.github/workflows/CI.yml` (in place)

`on:` triggers, `concurrency:`, and the workflow `name: "Tests"` are preserved verbatim, so the branch-protection status-check name is unchanged. The job body becomes:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

No `with:` inputs are needed: the old job used `tests.yml@v1` defaults (`check-bounds: yes`, `coverage: true`, single `ubuntu-latest`, default threads, no continue-on-error) and the root `test/runtests.jl` dispatches on the default `GROUP` env var (`get(ENV, "GROUP", "All")`).

### New `test/test_groups.toml`

```toml
[Core]
versions = ["lts", "1", "pre"]

[QA]
versions = ["lts", "1"]
```

This reproduces the old matrix exactly (the old workflow ran `group: [Core, QA] × version: [lts, 1, pre]` with `exclude: QA/pre`).

## Verified matrix match

Ran `scripts/compute_affected_sublibraries.jl <repo> --root-matrix` from `SciML/.github@v1` against the new `test/test_groups.toml` and compared its `(group, version)` set against the set the old `CI.yml` matrix produced:

```
OLD: [(Core,lts), (Core,1), (Core,pre), (QA,lts), (QA,1)]
NEW: [(Core,lts), (Core,1), (Core,pre), (QA,lts), (QA,1)]
missing: []   extra: []   EXACT MATCH: 5/5
```

TOML and both workflow YAML files parse cleanly. The package test suite was not run locally (heavy; CI validates).

---

Ignore until reviewed by @ChrisRackauckas.