### PR TITLE
Fix downgrade CI config (julia_floor)

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -18,6 +18,11 @@ jobs:
     uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
     secrets: "inherit"
     with:
+      # Numeric LTS floor: the reusable workflow forwards julia-version into
+      # julia-downgrade-compat@v2 as a registry compat spec (--julia=), which
+      # rejects channel aliases like "lts". Every sublibrary's compat floor is
+      # julia = "1.10", so pin the numeric value here.
+      julia-version: "1.10"
       group-env-name: "DIFFEQPROBLEMLIBRARY_TEST_GROUP"
       group-env-value: "Core"
       # Every lib/* sublibrary is downgrade-tested (projects auto-discovered, no exclusions).


### PR DESCRIPTION
## What

The **Downgrade Sublibraries** workflow has been failing on `master` (the regular **Downgrade** workflow is green). Every sublibrary job dies in the `julia-actions/julia-downgrade-compat@v2` step with:

```
[ERROR] Invalid compat version spec: --julia=lts
```

## Why

`DowngradeSublibraries.yml` passes no `julia-version`, so the reusable
`SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1` uses its default
`"lts"`. That reusable workflow forwards the value straight into
`julia-downgrade-compat@v2` as `julia_version`, which the action passes to its
resolver as a **registry compat version spec** (`--julia=lts`). The resolver
only accepts numeric compat versions (e.g. `1.10`), not channel aliases like
`lts`, so it errors out before any package resolution happens.

(The non-sublibrary `Downgrade` workflow does not hit this — it does not feed
`lts` into the compat action's `julia_version` — which is why only the
sublibrary variant is red.)

## Fix (config-only)

Pin the numeric LTS floor explicitly in the caller. Every `lib/*` sublibrary
declares `julia = "1.10"` (as does the root), so `1.10` is both a valid
setup-julia channel and a valid `--julia=` compat spec, and it satisfies every
sublibrary's floor.

No `Project.toml`, test, or source changes.

### Verification
- `actionlint .github/workflows/DowngradeSublibraries.yml` → clean (rc=0).
- `julia-version` resolves to `1.10`, which matches the `julia = "1.10"` compat
  floor of the root and all seven `lib/*` sublibraries.

Ignore until reviewed by @ChrisRackauckas.