### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ JumpProblemLibrary = "1, 2.0"
 NonlinearProblemLibrary = "0.1"
 ODEProblemLibrary = "1"
 SafeTestsets = "0.1"
+SciMLTesting = "1"
 SDEProblemLibrary = "1"
 Test = "1.10"
 julia = "1.10"
@@ -36,7 +37,8 @@ julia = "1.10"
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "SafeTestsets", "Test"]
+test = ["Pkg", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -16,5 +18,7 @@ SDEProblemLibrary = {path = "../../lib/SDEProblemLibrary"}
 [compat]
 DiffEqProblemLibrary = "5"
 ExplicitImports = "1"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
 Test = "1.10"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,43 +1,51 @@
 using Pkg
 using SafeTestsets, Test
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
+const GROUP = current_group()
+const LIB_DIR = joinpath(dirname(@__DIR__), "lib")
 
+# The root umbrella package's own QA env activation. It is kept as an explicit
+# helper (rather than `run_tests`'s `env =` group spec) so the activate/instantiate
+# behavior — in particular NOT `Pkg.develop`-ing the root or transitively developing
+# the env's `[sources]` on Julia < 1.11 — stays byte-for-byte identical to the
+# previous hand-written runtests.jl.
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
     return Pkg.instantiate()
 end
 
+# The root umbrella package's own test: it re-exports each sublibrary, so the test
+# is that the whole thing builds with no implicit or stale explicit imports. The old
+# runtests.jl ran this body for GROUP=All, GROUP=Core, and GROUP=QA alike, so it is
+# wired as the `qa` body, listed in `all`, and reached for GROUP=Core via an umbrella.
+function qa_group()
+    activate_qa_env()
+    return @time @safetestset "ExplicitImports" include("qa/qa.jl")
+end
+
 @time begin
-    # Detect sublibrary test groups.
-    # GROUP can be a bare sublibrary name (Core test group) or
-    # "{sublibrary}_{TEST_GROUP}" for any custom group (e.g., QA).
-    # Sublibraries declare their groups in test/test_groups.toml (when they
-    # differ from the default Core + QA).
-    lib_dir = joinpath(dirname(@__DIR__), "lib")
+    # Monorepo sublibrary routing. The root reads GROUP to pick a `lib/<sub>`
+    # sublibrary, transitively develops its `[sources]` on Julia < 1.11, then
+    # `Pkg.test`s it with the sub-group handed off via DIFFEQPROBLEMLIBRARY_TEST_GROUP.
+    # This is kept as an explicit pre-step (rather than delegated to `run_tests`'s
+    # built-in `lib_dir` path) so the sublibrary `Pkg.test` invocation — `julia_args`,
+    # `force_latest_compatible_version = false`, `allow_reresolve = true` — stays
+    # byte-for-byte identical to the previous runtests.jl. (`run_tests`'s sublibrary
+    # path only passes `allow_reresolve`, which would silently drop `--depwarn=yes` /
+    # `force_latest_compatible_version`.)
+    base_group, test_group = detect_sublibrary_group(GROUP, LIB_DIR)
 
-    # Scan underscores right-to-left to find the longest matching sublibrary prefix.
-    function _detect_sublibrary_group(group, lib_dir)
-        isdir(joinpath(lib_dir, group)) && return (group, "Core")
-        for i in length(group):-1:1
-            if group[i] == '_' && isdir(joinpath(lib_dir, group[1:(i - 1)]))
-                return (group[1:(i - 1)], group[(i + 1):end])
-            end
-        end
-        return (group, "Core")
-    end
-    base_group, test_group = _detect_sublibrary_group(GROUP, lib_dir)
-
-    if isdir(joinpath(lib_dir, base_group))
-        Pkg.activate(joinpath(lib_dir, base_group))
+    if !isempty(base_group) && isdir(joinpath(LIB_DIR, base_group))
+        Pkg.activate(joinpath(LIB_DIR, base_group))
         # On Julia < 1.11, the [sources] section in Project.toml is not supported.
         # Manually Pkg.develop local path dependencies so CI tests the PR branch code.
         # The transitive walk also develops each developed dependency's own [sources].
         if VERSION < v"1.11.0-DEV.0"
             developed = Set{String}()
-            push!(developed, normpath(joinpath(lib_dir, base_group)))
+            push!(developed, normpath(joinpath(LIB_DIR, base_group)))
             specs = Pkg.PackageSpec[]
-            queue = [joinpath(lib_dir, base_group)]
+            queue = [joinpath(LIB_DIR, base_group)]
             while !isempty(queue)
                 pkg_dir = popfirst!(queue)
                 toml_path = joinpath(pkg_dir, "Project.toml")
@@ -62,11 +70,16 @@ end
         withenv("DIFFEQPROBLEMLIBRARY_TEST_GROUP" => test_group) do
             Pkg.test(base_group, julia_args = ["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true)
         end
-    elseif GROUP == "All" || GROUP == "Core" || GROUP == "QA"
-        # The root umbrella package's own test: it re-exports each sublibrary,
-        # so the test is that the whole thing builds with no implicit or stale
-        # explicit imports.
-        activate_qa_env()
-        @time @safetestset "ExplicitImports" include("qa/qa.jl")
+    else
+        # Root-package group dispatch. The previous runtests.jl ran the same
+        # ExplicitImports QA body for GROUP=All, GROUP=Core, and GROUP=QA. `run_tests`
+        # owns that routing: `qa` is the body, `all = ["QA"]` runs it under "All", and
+        # the "Core" umbrella expands to "QA" so GROUP=Core runs it too.
+        run_tests(;
+            core = () -> nothing,
+            qa = qa_group,
+            all = ["QA"],
+            umbrellas = Dict("Core" => ["QA"]),
+        )
     end
 end # @time


### PR DESCRIPTION
Converts the root umbrella package's test harness to the SciMLTesting v1.2 folder model.

DiffEqProblemLibrary is a monorepo: the `lib/*` sublibraries are covered by `SublibraryCI.yml` (the project model), and the root umbrella's own group matrix (`test/test_groups.toml`) is just `Core` + `QA`. The root runtests.jl previously ran the same ExplicitImports QA body for `GROUP=All`, `GROUP=Core`, and `GROUP=QA`, and routed any `lib/<sub>` sublibrary group to a hand-written `Pkg.test` pre-step.

This PR:
- Keeps the monorepo sublibrary routing pre-step **verbatim** (`detect_sublibrary_group` + the Julia < 1.11 transitive `[sources]` develop walk + the `Pkg.test` with `--check-bounds=auto --compiled-modules=yes --depwarn=yes`, `force_latest_compatible_version = false`, `allow_reresolve = true`, handed off via `DIFFEQPROBLEMLIBRARY_TEST_GROUP`). This is kept explicit rather than delegated to `run_tests`'s built-in `lib_dir` path so the sublibrary `Pkg.test` invocation stays byte-for-byte identical.
- Delegates the root-package dispatch to `run_tests`: `qa` body = the ExplicitImports test, `all = ["QA"]` so `GROUP=All` runs it, and a `"Core"` umbrella expanding to `"QA"` so `GROUP=Core` runs it too. `core` is a no-op (the root has no separate Core body).
- Adds `SciMLTesting` to the root and `test/qa` test environments.
- Leaves `test/test_groups.toml` unchanged.

The exact set of tests run under each `GROUP` value (`All`/`Core`/`QA` -> ExplicitImports QA; each `lib/<sub>` -> that sublibrary's `Pkg.test`; unknown group -> nothing) is preserved.

Ignore until reviewed by @ChrisRackauckas.
