### PR TITLE
Fix QA/Core CI: drop unmatched sublibrary [sources] from test/qa/Project.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -75,3 +75,7 @@ MTK = "MTK"
 ODE = "ODE"
 PDE = "PDE"
 SDE = "SDE"
+
+# Citation false-positives
+Comput = "Comput"  # "Math. Comput." journal abbreviation
+Collum = "Collum"  # surname "McCollum" (paper author)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,14 +6,7 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-BVProblemLibrary = {path = "../../lib/BVProblemLibrary"}
-DAEProblemLibrary = {path = "../../lib/DAEProblemLibrary"}
-DDEProblemLibrary = {path = "../../lib/DDEProblemLibrary"}
 DiffEqProblemLibrary = {path = "../.."}
-JumpProblemLibrary = {path = "../../lib/JumpProblemLibrary"}
-NonlinearProblemLibrary = {path = "../../lib/NonlinearProblemLibrary"}
-ODEProblemLibrary = {path = "../../lib/ODEProblemLibrary"}
-SDEProblemLibrary = {path = "../../lib/SDEProblemLibrary"}
 
 [compat]
 DiffEqProblemLibrary = "5"


### PR DESCRIPTION
## Problem

Master CI is red. The `tests / Core (julia 1)`, `tests / Core (julia pre)`, and `tests / QA (julia 1)` jobs all fail at environment activation:

```
ERROR: LoadError: Sources for `JumpProblemLibrary` not listed in `deps` or `extras` section
at ".../test/qa/Project.toml".
```

`test/qa/Project.toml` listed every sublibrary (`BVProblemLibrary`, `DAEProblemLibrary`, `DDEProblemLibrary`, `JumpProblemLibrary`, `NonlinearProblemLibrary`, `ODEProblemLibrary`, `SDEProblemLibrary`) under `[sources]`, but only `DiffEqProblemLibrary` is declared in `[deps]`. On the current CI Julia (1.12.6), `Pkg.activate` validates the project and rejects any `[sources]` key without a matching `[deps]`/`[extras]` entry.

This breaks both the **QA** group and the **Core** group, since `Core` reaches the same `activate_qa_env` path through the `Core => QA` umbrella in `runtests.jl`.

## Fix

The qa env only needs `DiffEqProblemLibrary` (the QA test, `qa/qa.jl`, just runs `ExplicitImports` checks on `DiffEqProblemLibrary`). The root package's own `[sources]` transitively resolve the sublibraries, so the per-sublibrary `[sources]` entries in the qa env were spurious. Keep only `DiffEqProblemLibrary = {path = "../.."}`.

## Local verification (Julia 1.12.6, same as CI's "julia 1")

Before (reproduces the CI failure):
```
ACTIVATE_ERROR: Sources for `JumpProblemLibrary` not listed in `deps` or `extras` section ...
```

After (this branch):
```
ACTIVATE_OK
INSTANTIATE_OK
Test Summary:   | Pass  Total   Time
ExplicitImports |    2      2  15.8s
QA_GROUP_OK
```

This does not address the separate `downgrade-sublibraries / test (lib/BVProblemLibrary)` failure (`UndefVarError: BVPFunction not defined` at the downgrade compat floor), which is a pre-existing downgrade compat-floor issue tracked separately.

Please ignore until reviewed by @ChrisRackauckas.
