### PR TITLE
Raise BVProblemLibrary DiffEqBase compat floor to 6.158 (fix downgrade CI)

### DIFF
--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -8,7 +8,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-DiffEqBase = "6, 7"
+DiffEqBase = "6.158, 7"
 Markdown = "1.10"
 SafeTestsets = "0.1"
 SpecialFunctions = "2.3"

--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -10,6 +10,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 DiffEqBase = "6.158, 7"
 Markdown = "1.10"
+Pkg = "1.10"
 SafeTestsets = "0.1"
 SpecialFunctions = "2.3"
 Test = "1.10"


### PR DESCRIPTION
## Problem

The `downgrade-sublibraries / test (lib/BVProblemLibrary)` job is red on `master`. It fails with:

```
ERROR: LoadError: UndefVarError: `BVPFunction` not defined
  @ lib/BVProblemLibrary/src/linear.jl:22
```

## Root cause (downgrade)

`lib/BVProblemLibrary/Project.toml` declared `DiffEqBase = "6, 7"`. The downgrade resolver therefore selected **DiffEqBase 6.0.0**, an ancient release that:

- predates `BVPFunction` (re-exported into DiffEqBase from SciMLBase), which `src/linear.jl` and `src/BVProblemLibrary.jl` use throughout; and
- does not even precompile on Julia 1.10 (`Base.@_pure_meta` import failure, `combine_axes` method-overwriting-during-precompilation error).

From the registry, DiffEqBase only requires `julia = "1.10"` starting at **6.158**, and 6.158's SciMLBase dependency floor (2.60.0) already provides `BVPFunction`.

## Fix 1 — raise DiffEqBase floor

Raise the lower bound: `DiffEqBase = "6.158, 7"`. Raising a floor never loosens anything; it only excludes the broken-on-1.10 ancient versions. The 7.x line is unchanged.

## Fix 2 — add `Pkg` compat (Aqua deps_compat on Julia 1.12)

Touching `lib/BVProblemLibrary/Project.toml` makes the `sublibraries / lib/BVProblemLibrary [QA]` job run, which exposed a pre-existing latent Aqua finding on **Julia 1.12** (it does not fire on 1.10):

```
BVProblemLibrary does not declare a compat entry for the following extras: Pkg
Aqua deps_compat: Test Failed ... isempty(result) -> Pkg
```

`Pkg` is in `[extras]`/`[targets]` (used by `test/runtests.jl` to activate the `qa` env) but had no `[compat]` entry. Added `Pkg = "1.10"`, matching the existing `Markdown`/`Test` stdlib pins. Real fix, no test weakening.

## Local verification

- **Julia 1.10 (downgrade channel)**: at the new floor pinned to its minimum (DiffEqBase 6.158 + SciMLBase 2.60.0) `BVProblemLibrary` precompiles and loads, `prob_bvp_linear_1` is a `BVProblem{..., BVPFunction{...}}`, and `Pkg.test()` passes. DiffEqBase 6.157 is correctly rejected (`empty intersection ... 6.158.0-7`), confirming the floor is tight.
- **Julia 1.12.6 (the failing QA job)**: `DIFFEQPROBLEMLIBRARY_TEST_GROUP=QA Pkg.test()` for `lib/BVProblemLibrary` now reports `Aqua | 10 10` (was 9 pass / 1 fail before adding the `Pkg` compat).

Please ignore until reviewed by @ChrisRackauckas