### PR TITLE
Bump version to 5.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqProblemLibrary"
 uuid = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.2.1"
+version = "5.2.2"
 
 [deps]
 BVProblemLibrary = "ded0fc24-dfea-4565-b1d9-79c027d14d84"


### PR DESCRIPTION
Automated patch version bump (5.2.1 -> 5.2.2) to release unreleased commits on `master` via JuliaRegistrator.