### PR TITLE
Drop DiffEqProblemLibrary QA self sources

### DIFF
--- a/lib/BVProblemLibrary/test/qa/Project.toml
+++ b/lib/BVProblemLibrary/test/qa/Project.toml
@@ -4,9 +4,6 @@ BVProblemLibrary = "ded0fc24-dfea-4565-b1d9-79c027d14d84"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-BVProblemLibrary = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 BVProblemLibrary = "0.1"

--- a/lib/BVProblemLibrary/test/runtests.jl
+++ b/lib/BVProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/lib/DAEProblemLibrary/test/qa/Project.toml
+++ b/lib/DAEProblemLibrary/test/qa/Project.toml
@@ -4,9 +4,6 @@ DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DAEProblemLibrary = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 DAEProblemLibrary = "0.1"

--- a/lib/DAEProblemLibrary/test/runtests.jl
+++ b/lib/DAEProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/lib/DDEProblemLibrary/test/qa/Project.toml
+++ b/lib/DDEProblemLibrary/test/qa/Project.toml
@@ -4,9 +4,6 @@ DDEProblemLibrary = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DDEProblemLibrary = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 DDEProblemLibrary = "0.1"

--- a/lib/DDEProblemLibrary/test/runtests.jl
+++ b/lib/DDEProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/lib/JumpProblemLibrary/test/qa/Project.toml
+++ b/lib/JumpProblemLibrary/test/qa/Project.toml
@@ -4,9 +4,6 @@ JumpProblemLibrary = "faf0f6d7-8cee-47cb-b27c-1eb80cef534e"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-JumpProblemLibrary = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JumpProblemLibrary = "2"

--- a/lib/JumpProblemLibrary/test/runtests.jl
+++ b/lib/JumpProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/lib/NonlinearProblemLibrary/test/qa/Project.toml
+++ b/lib/NonlinearProblemLibrary/test/qa/Project.toml
@@ -5,9 +5,6 @@ NonlinearProblemLibrary = "b7050fa9-e91f-4b37-bcee-a89a063da141"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-NonlinearProblemLibrary = {path = "../.."}
-
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8"

--- a/lib/NonlinearProblemLibrary/test/runtests.jl
+++ b/lib/NonlinearProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/lib/ODEProblemLibrary/test/qa/Project.toml
+++ b/lib/ODEProblemLibrary/test/qa/Project.toml
@@ -4,9 +4,6 @@ ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ODEProblemLibrary = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 ODEProblemLibrary = "1"

--- a/lib/ODEProblemLibrary/test/runtests.jl
+++ b/lib/ODEProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/lib/SDEProblemLibrary/test/qa/Project.toml
+++ b/lib/SDEProblemLibrary/test/qa/Project.toml
@@ -4,9 +4,6 @@ SDEProblemLibrary = "c72e72a9-a271-4b2b-8966-303ed956772e"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SDEProblemLibrary = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 SDEProblemLibrary = "1"

--- a/lib/SDEProblemLibrary/test/runtests.jl
+++ b/lib/SDEProblemLibrary/test/runtests.jl
@@ -6,6 +6,7 @@ const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(Pkg.PackageSpec(path = dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -4,9 +4,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DiffEqProblemLibrary = {path = "../.."}
-
 [compat]
 DiffEqProblemLibrary = "5"
 SafeTestsets = "0.0.1, 0.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,27 +5,9 @@ using SciMLTesting
 const GROUP = current_group()
 const LIB_DIR = joinpath(dirname(@__DIR__), "lib")
 
-# The root umbrella package's own QA env activation. On Julia < 1.11 the env's
-# `[sources]` table is ignored by Pkg, so `DiffEqProblemLibrary = {path = "../.."}`
-# would silently resolve to the registered release instead of the working copy —
-# meaning the QA checks (Aqua.test_all etc.) run against the registry version, not
-# the branch under CI. Develop the env's local path sources first, mirroring the
-# sublibrary branch below, so the checks test the working tree.
 function activate_qa_env()
     qa_dir = joinpath(@__DIR__, "qa")
-    Pkg.activate(qa_dir)
-    if VERSION < v"1.11.0-DEV.0"
-        toml = Pkg.TOML.parsefile(joinpath(qa_dir, "Project.toml"))
-        specs = Pkg.PackageSpec[]
-        for (_, source_spec) in get(toml, "sources", Dict())
-            if source_spec isa Dict && haskey(source_spec, "path")
-                dep_path = normpath(joinpath(qa_dir, source_spec["path"]))
-                isdir(dep_path) && push!(specs, Pkg.PackageSpec(path = dep_path))
-            end
-        end
-        isempty(specs) || Pkg.develop(specs)
-    end
-    return Pkg.instantiate()
+    return activate_group_env(qa_dir; parent = dirname(@__DIR__))
 end
 
 # The root umbrella package's own test: it re-exports each sublibrary, so the test


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Summary

- Remove committed self `[sources]` path entries from the root and sublibrary `test/qa/Project.toml` files.
- Keep the root QA activation on `SciMLTesting.activate_group_env`.
- For sublibraries, explicitly `Pkg.develop` the local sublibrary package before activating the QA environment, avoiding committed path sources without adding SciMLTesting to the outer test env.

## Verification

- `rg -n "^\[sources\]|path\s*=" test/qa/Project.toml lib/*/test/qa/Project.toml` returned no matches.
- Runic passed on the touched `runtests.jl` files.
- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n  - passed: root `ExplicitImports | 18/18`.\n- Sublibrary QA passed with `DIFFEQPROBLEMLIBRARY_TEST_GROUP=QA`:\n  - `BVProblemLibrary`: Aqua `17/17`\n  - `DAEProblemLibrary`: Aqua `17/17`\n  - `DDEProblemLibrary`: Aqua `17/17`\n  - `JumpProblemLibrary`: Aqua `16/16`\n  - `NonlinearProblemLibrary`: Allocation `3/3`, Aqua `17/17`\n  - `ODEProblemLibrary`: Aqua `17/17`\n  - `SDEProblemLibrary`: Aqua `16/16`\n