### PR TITLE
Release prep: batched version bumps for 8 packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqProblemLibrary"
 uuid = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.2.2"
+version = "5.2.3"
 
 [deps]
 BVProblemLibrary = "ded0fc24-dfea-4565-b1d9-79c027d14d84"

--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "BVProblemLibrary"
 uuid = "ded0fc24-dfea-4565-b1d9-79c027d14d84"
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/DAEProblemLibrary/Project.toml
+++ b/lib/DAEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "DAEProblemLibrary"
 uuid = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "DDEProblemLibrary"
 uuid = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/JumpProblemLibrary/Project.toml
+++ b/lib/JumpProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "JumpProblemLibrary"
 uuid = "faf0f6d7-8cee-47cb-b27c-1eb80cef534e"
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"

--- a/lib/NonlinearProblemLibrary/Project.toml
+++ b/lib/NonlinearProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearProblemLibrary"
 uuid = "b7050fa9-e91f-4b37-bcee-a89a063da141"
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "ODEProblemLibrary"
 uuid = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/SDEProblemLibrary/Project.toml
+++ b/lib/SDEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "SDEProblemLibrary"
 uuid = "c72e72a9-a271-4b2b-8966-303ed956772e"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
## Summary

Patch-releases 8 packages in this monorepo whose default-branch trees have
diverged from their last registered version. Each package's changes since
its last release commit were audited scoped to that package's own
subdirectory (root scoped to non-`lib/` paths):

| Package | Old | New | Reason |
|---|---|---|---|
| DiffEqProblemLibrary (root) | 5.2.2 | 5.2.3 | Own changes: SciMLTesting compat floor raise (1.7 -> 2.1), QA harness update (`api_docs_kwargs`), monorepo TagBot workflow rework, test-runner simplification (`activate_group_env`). No non-test source changes. |
| BVProblemLibrary | 0.1.10 | 0.1.11 | Own changes: `using DiffEqBase, Markdown, SpecialFunctions` -> explicit import lists (no new symbols pulled in); QA/test scaffolding updated to `SciMLTesting.run_qa`. |
| DAEProblemLibrary | 0.1.4 | 0.1.5 | Own changes: same explicit-import mechanical cleanup; `Pkg` compat floor added; QA/test scaffolding update. |
| DDEProblemLibrary | 0.1.6 | 0.1.7 | Own changes: same explicit-import cleanup; `Pkg` compat floor added; QA/test scaffolding update. |
| JumpProblemLibrary | 2.0.1 | 2.0.2 | Own changes: `using Catalyst` -> explicit import list; `Pkg` compat floor added; QA/test scaffolding update. |
| NonlinearProblemLibrary | 0.1.6 | 0.1.7 | Own changes: explicit-import cleanup; new docstring on the existing exported `nlprob_23_testcases` constant (no new export); `Pkg` compat floor added; QA/test scaffolding update. |
| ODEProblemLibrary | 1.5.1 | 1.5.2 | Own changes: explicit-import cleanup; docstrings added to existing exported names (`SolverDiffEq`, `filament_prob`, `prob_ode_mm_linear`, the strange-attractor `ODEFunction`s); export list unchanged; QA/test scaffolding update. |
| SDEProblemLibrary | 1.2.1 | 1.2.2 | Own changes: explicit-import cleanup; docstrings added to existing exported problems (`prob_sde_linear_stratonovich`, `prob_sde_2Dlinear_stratonovich`); export list unchanged; QA/test scaffolding update. |

All changes were classified SAFE: mechanical `using X` -> explicit `using X: a, b, c`
import-list rewrites verified to add no new imported symbols, pure docstring
additions to already-exported names (verified via `export` line diffs -- no
package's export list changed), QA/CI/test scaffolding, and dev-dependency
(`SciMLTesting`) compat floor raises. No genuine new public API, no changed
signatures, no new required runtime dependencies. All bumps are **patch**
releases.

### Compat floor cascade

No `lib/*` package in this monorepo depends on another `lib/*` package (each
sublibrary's `[deps]` only references external packages: `DiffEqBase`,
`SciMLBase`, `Catalyst`, etc.), so there is no sibling-to-sibling cascade to
check.

Root's `[compat]` entries on each sublibrary (`BVProblemLibrary = "0.1"`,
`DAEProblemLibrary = "0.1"`, `DDEProblemLibrary = "0.1"`,
`JumpProblemLibrary = "1, 2.0"`, `NonlinearProblemLibrary = "0.1"`,
`ODEProblemLibrary = "1"`, `SDEProblemLibrary = "1"`) already admit each new
patch version, and none of the sublibrary changes add public API that root's
own source (which has none beyond re-exporting) relies on -- so no compat
floor raises were needed in root's `Project.toml`. Root is included in this
PR because it has its own qualifying SAFE changes, not solely for cascade
reasons.

## Test plan

- [x] Diffed each package's own subdirectory between its last-registered
      commit and current HEAD to confirm scope and classify every change.
- [x] Confirmed no package's `export` list changed (verified with a diff of
      the `export` block in each sublibrary's main module file).
- [x] Confirmed no new source files were added and no cross-lib dependencies
      exist.
- [ ] CI (grouped test matrix + QA) green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
