### PR TITLE
Target the DiffEqDevTools monorepo test project

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,14 +12,15 @@ jobs:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
     runs-on: ${{ matrix.os }}
     env:
-      GROUP: ${{ matrix.package.group }}
+      ODEDIFFEQ_TEST_GROUP: ${{ matrix.package.group }}
+      DOWNSTREAM_SUBDIR: ${{ matrix.package.subdir }}
     strategy:
       fail-fast: false
       matrix:
         julia-version: ['1.10']
         os: [ubuntu-latest]
         package:
-          - {user: SciML, repo: DiffEqDevTools.jl, group: All}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqDevTools, group: Core}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression_I}
     steps:
       - uses: actions/checkout@v7
@@ -33,17 +34,16 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
+        shell: julia --color=yes {0}
         run: |
           using Pkg
-          try
-            Pkg.develop(map(path ->Pkg.PackageSpec.(;path="lib/$(path)"), readdir("./lib")));
-            Pkg.test(coverage=true)
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)
-          end
+          downstream_project = normpath(joinpath("downstream", ENV["DOWNSTREAM_SUBDIR"]))
+          isfile(joinpath(downstream_project, "Project.toml")) ||
+            error("No downstream Project.toml found at $(downstream_project)")
+          Pkg.activate(downstream_project)
+          Pkg.develop(map(path -> Pkg.PackageSpec(; path = joinpath(pwd(), "lib", path)), readdir("lib")))
+          Pkg.update()
+          Pkg.test(coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Audit finding

The downstream workflow still cloned the archived standalone `DiffEqDevTools.jl` repository and selected `All`. DiffEqDevTools is now registered from `OrdinaryDiffEq.jl:lib/DiffEqDevTools`, whose focused group is `Core` and whose direct runner reads `ODEDIFFEQ_TEST_GROUP`. The workflow also caught resolver errors and converted them to success.

## Changes

- clone `OrdinaryDiffEq.jl` and activate `lib/DiffEqDevTools`;
- select the populated `Core` group through `ODEDIFFEQ_TEST_GROUP`;
- keep the existing root OrdinaryDiffEq `Regression_I` row;
- activate and test the selected project explicitly;
- develop all DiffEqProblemLibrary subpackages into the downstream environment;
- let resolver and test failures propagate.

## Local verification

- actionlint passed for `.github/workflows/Downstream.yml`.
- Runic.jl repository check passed.
- `OrdinaryDiffEq/Regression_I`: exit 0; OrdinaryDiffEq tests passed.
- Workflow-equivalent Julia 1.10.11 `DiffEqDevTools/Core`: exit 0. Final sets included Plot Recipes 36/36 and nonlinear-solve work-precision diagrams 6/6; Pkg reported `DiffEqDevTools tests passed`.
- `git diff --check` passed.

An earlier `All` run exposed unrelated pre-existing QA/documentation coverage failures; those are being handled separately in SciML/OrdinaryDiffEq.jl#3906. This workflow now requests only the intended populated Core group.