### PR TITLE
Bump DiffEqProblemLibrary subpackage versions

### DIFF
--- a/lib/BVProblemLibrary/Project.toml
+++ b/lib/BVProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "BVProblemLibrary"
 uuid = "ded0fc24-dfea-4565-b1d9-79c027d14d84"
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/DAEProblemLibrary/Project.toml
+++ b/lib/DAEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "DAEProblemLibrary"
 uuid = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/DDEProblemLibrary/Project.toml
+++ b/lib/DDEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "DDEProblemLibrary"
 uuid = "f42792ee-6ffc-4e2a-ae83-8ee2f22de800"
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "ODEProblemLibrary"
 uuid = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
-version = "1.5.2"
+version = "1.5.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/lib/SDEProblemLibrary/Project.toml
+++ b/lib/SDEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "SDEProblemLibrary"
 uuid = "c72e72a9-a271-4b2b-8966-303ed956772e"
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Bumps the following subpackages so their accumulated unreleased `src/` changes can be registered:

- `BVProblemLibrary` v0.1.11 → **v0.1.12** (patch) — Migrate DiffEqProblemLibrary to SciMLTesting 2.4 (#214) (docs/QA/compat/internal; no public API or behavior break)
- `DAEProblemLibrary` v0.1.5 → **v0.1.6** (patch) — Migrate DiffEqProblemLibrary to SciMLTesting 2.4 (#214) (docs/QA/compat/internal; no public API or behavior break)
- `DDEProblemLibrary` v0.1.7 → **v0.1.8** (patch) — Migrate DiffEqProblemLibrary to SciMLTesting 2.4 (#214) (docs/QA/compat/internal; no public API or behavior break)
- `ODEProblemLibrary` v1.5.2 → **v1.5.3** (patch) — Migrate DiffEqProblemLibrary to SciMLTesting 2.4 (#214) (docs/QA/compat/internal; no public API or behavior break)
- `SDEProblemLibrary` v1.2.2 → **v1.2.3** (patch) — Migrate DiffEqProblemLibrary to SciMLTesting 2.4 (#214) (docs/QA/compat/internal; no public API or behavior break)

Each bump reflects the semantic level of its diff (patch unless new public API was added). Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)