### PR TITLE
Use GROUP for monorepo test routing

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -18,6 +18,6 @@ jobs:
     uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
     secrets: "inherit"
     with:
-      group-env-name: "DIFFEQPROBLEMLIBRARY_TEST_GROUP"
+      group-env-name: "GROUP"
       group-env-value: "Core"
       # Every lib/* sublibrary is downgrade-tested (projects auto-discovered, no exclusions).

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
     runs-on: ${{ matrix.os }}
     env:
-      ODEDIFFEQ_TEST_GROUP: ${{ matrix.package.group }}
+      GROUP: ${{ matrix.package.group }}
       DOWNSTREAM_SUBDIR: ${{ matrix.package.subdir }}
     strategy:
       fail-fast: false

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -20,6 +20,6 @@ jobs:
   sublibraries:
     uses: "SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1"
     with:
-      group-env-name: DIFFEQPROBLEMLIBRARY_TEST_GROUP
+      group-env-name: GROUP
       check-bounds: auto
     secrets: "inherit"

--- a/lib/BVProblemLibrary/test/runtests.jl
+++ b/lib/BVProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using BVProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/lib/DAEProblemLibrary/test/runtests.jl
+++ b/lib/DAEProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using DAEProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/lib/DDEProblemLibrary/test/runtests.jl
+++ b/lib/DDEProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using DDEProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/lib/JumpProblemLibrary/test/runtests.jl
+++ b/lib/JumpProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using JumpProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/lib/NonlinearProblemLibrary/test/runtests.jl
+++ b/lib/NonlinearProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using NonlinearProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/lib/ODEProblemLibrary/test/runtests.jl
+++ b/lib/ODEProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using ODEProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/lib/SDEProblemLibrary/test/runtests.jl
+++ b/lib/SDEProblemLibrary/test/runtests.jl
@@ -2,7 +2,7 @@ using Pkg
 using SDEProblemLibrary
 using SafeTestsets, Test
 
-const TEST_GROUP = get(ENV, "DIFFEQPROBLEMLIBRARY_TEST_GROUP", "All")
+const TEST_GROUP = get(ENV, "GROUP", "All")
 
 function activate_qa_env()
     Pkg.activate(joinpath(@__DIR__, "qa"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ end
 
     if !isempty(base_group) && isdir(joinpath(LIB_DIR, base_group))
         Pkg.activate(joinpath(LIB_DIR, base_group))
-        withenv("DIFFEQPROBLEMLIBRARY_TEST_GROUP" => test_group) do
+        withenv("GROUP" => test_group) do
             Pkg.test(base_group, julia_args = ["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true)
         end
     else


### PR DESCRIPTION
## Summary

- use the standard uppercase GROUP environment variable in every DiffEqProblemLibrary sublibrary runner
- use GROUP for the root-to-sublibrary handoff and reusable sublibrary CI workflows
- pass GROUP to OrdinaryDiffEq from the custom downstream workflow

## Why

SciML reusable downstream workflows use GROUP. Keeping a monorepo-specific handoff variable made DiffEqProblemLibrary inconsistent, and its custom downstream job used the retired OrdinaryDiffEq variable for the migrated DiffEqDevTools lane.

Ignore this PR until reviewed by @ChrisRackauckas.

## Local verification

- Julia 1.12: GROUP=ODEProblemLibrary_Core Pkg.test(): passed through the root-to-sublibrary route
- Runic check for lib and test/runtests.jl
- actionlint for all modified workflow files
- git diff --check