### PR TITLE
Set ODEProblemLibrary version to 1.5.4

### DIFF
--- a/lib/ODEProblemLibrary/Project.toml
+++ b/lib/ODEProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "ODEProblemLibrary"
 uuid = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
-version = "1.5.3"
+version = "1.5.4"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| ODEProblemLibrary | 1.5.3 | 1.5.3 | 1.5.4 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:   | Pass  Total     Time / ExplicitImports |   20     20  2m16.7s / Testing DiffEqProblemLibrary tests passed`
- `GROUP=ODEProblemLibrary /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total  Time / Load Tests    |    1      1  0.0s / Test Summary: | Pass  Total  Time / Filament      |    8      8  1.4s / Testing DiffEqProblemLibrary tests passed`
- `GROUP=ODEProblemLibrary_QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total   Time / Aqua          |   20     20  33.2s / Testing DiffEqProblemLibrary tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude lib/ODEProblemLibrary/Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- ODEProblemLibrary: `@JuliaRegistrator register subdir=lib/ODEProblemLibrary`