### PR TITLE
Ignore extras-only Aqua stale_deps in run_qa

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,7 @@
 using SciMLTesting, DiffEqProblemLibrary, Test
 
-run_qa(DiffEqProblemLibrary)
+# extras-only harness deps; Aqua sees them after Pkg.test extras-merge
+run_qa(
+    DiffEqProblemLibrary;
+    aqua_kwargs = (; stale_deps = (; ignore = [:SafeTestsets, :SciMLTesting])),
+)


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

`test/qa/qa.jl` now passes Aqua `stale_deps` ignores for `SafeTestsets` and `SciMLTesting` through `run_qa`'s `aqua_kwargs`. No package version or `[compat]` change.

## Why

Default-branch Downgrade is red while Tests are green ([run](https://github.com/SciML/DiffEqProblemLibrary.jl/actions/runs/31863096765)). `run_qa(DiffEqProblemLibrary)` runs Aqua against the extras-merged sandbox. `SafeTestsets` and `SciMLTesting` live in root `[extras]` (test harness only) and are flagged as stale deps.

SciMLTesting 2.4–2.9 `run_qa` does not auto-ignore extras. Aqua's `stale_deps = (; ignore = ...)` is the supported per-check API. Other Aqua checks are unchanged.

## Verification

CI fail-before (Aqua 0.8.16):

```
Stale dependencies: Test Failed
  Expression: isempty(stale_deps)
  Evaluated: isempty(Base.PkgId[SafeTestsets [...], SciMLTesting [...]])
```

`run_qa` forwards `aqua_kwargs` to `Aqua.test_all` (SciMLTesting 2.4+).

Not verified here: a live `julia-downgrade-compat` re-run of the full Core group.

## Reviewer note

This is a test-only Aqua ignore for extras that are not package deps. A `[compat]` bump cannot fix extras-merge stale_deps.
